### PR TITLE
use setuptools.setup, add entry_points.console_scripts, remove old script

### DIFF
--- a/randomfiletree/bin/randomfiletree
+++ b/randomfiletree/bin/randomfiletree
@@ -1,7 +1,0 @@
-#!/usr/bin/env python3
-
-from randomfiletree.cli import cli
-
-
-if __name__ == "__main__":
-    cli()

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,8 @@
 #!/usr/bin/env python3
 
-# std
-from distutils.core import setup
 # noinspection PyUnresolvedReferences
-import setuptools  # see below (1)
+import setuptools
 from pathlib import Path
-
-# (1) see https://stackoverflow.com/questions/8295644/
-# Without this import, install_requires won't work.
-
 
 keywords = [
     "testing",
@@ -29,7 +23,7 @@ with (this_dir / "README.rst").open() as fh:
 with (this_dir / "randomfiletree" / "version.txt").open() as vf:
     version = vf.read()
 
-setup(
+setuptools.setup(
     name='RandomFileTree',
     version=version,
     packages=packages,
@@ -44,7 +38,9 @@ setup(
     },
     install_requires=[],
     license="MIT",
-    scripts=["randomfiletree/bin/randomfiletree"],
+    entry_points={
+        "console_scripts": ["randomfiletree=randomfiletree.cli:cli"]
+    },
     keywords=keywords,
     description=description,
     long_description=long_description,


### PR DESCRIPTION
Hello again!

This removes the `bin` (which wasn't going to work at all on windows), favoring the more modern, cross-platform `console_scripts`. As `setuptools` was already being imported, it didn't seem like that big of a stretch.

I've applied this patch (and worked around #3) on https://github.com/conda-forge/staged-recipes/pull/14862 and it passes the full test suite and effectively uses the CLI on linux, windows, and macos
